### PR TITLE
Moved Father Time & Mother Nature

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Phrases with "man" can change to use "one" or "person".
     <tr><td>forefathers, foremothers</td><td>foreparents, forebearers, ancestors</td></tr>
     <tr><td>founding fathers, founding mothers</td><td>founding parents, founding leaders, founders</td></tr>
     <tr><td>gentlemen's agreement, gentlewomen's agreement</td><td>unwritten agreement, honor agreement</td></tr>
-    <tr><td>grandfather clause, grandmother clause</td><td>pre-existing clause, pre-defined clause</td></tr>
+    <tr><td>grandfather clause, grandmother clause</td><td>pre-existing clause, pre-defined clause, legacy clause</td></tr>
     <tr><td>low man on the totem pole</td><td>low person on the list, least one in the group</td></tr>
     <tr><td>maiden voyage</td><td>first voyage</td></tr>
     <tr><td>man about town, woman about town</td><td>bon vivant, mover and shaker</td></tr>

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Phrases with "man" can change to use "one" or "person".
     <tr><td>man of letters, woman of letters</td><td>person of letters, academic, scholar</td></tr>
     <tr><td>man of the hour, woman of the hour</td><td>person of the hour, newsmaker of the hour</td></tr>
     <tr><td>man to man, woman to woman</td><td>person to person, face to face, head to head</td></tr>
-    <tr><td>no-man's land</td><td>no-go land, neutral zone, uninhabited area</td></tr>
+    <tr><td>no-man's land</td><td>no-go land, neutral zone, uninhabited area, unclaimed land</td></tr>
     <tr><td>no man is an island</td><td>no one is an island</td></tr>
     <tr><td>the common man</td><td>the common person, the average person</td></tr>
     <tr><td>the man in the street</td><td>the person in the street, the average person</td></tr>

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Expressions that involve gendered first names
     <tr><td>brotherly love, sisterly love</td><td>siblingly love, charity, goodwill</td></tr>
     <tr><td>coed</td><td>student</td></tr>
     <tr><td>man (verb)</td><td>to guard, to staff, to operate, to mind [the store]</td></tr>
-    <tr><td>man-made, woman-made</td><td>synthetic, artificial, hand-made, machine-made</td></tr>
+    <tr><td>man-made, woman-made</td><td>human-made, synthetic, artificial, hand-made, machine-made</td></tr>
     <tr><td>manhole</td><td>utility hole, access hole, sewer hole, maintenance hole</td></tr>
     <tr><td>manpower, womanpower</td><td>personpower, teampower, workers, workforce, staff</td></tr>
     <tr><td>meter-maid, meter-matron, meter-man</td><td>meter-reader, parking enforcement officer, PEO, parking officer, parking inspector, traffic warden, civil enforcement officer</td></tr>

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>careerman, careerwoman</td><td>careerperson, business person, professional</td></tr>
     <tr><td>caveman, cavewoman</td><td>cave person, cave dweller</td></tr>
     <tr><td>chairman, chairwoman</td><td>chair, chairperson, coordinator, head</td></tr>
-    <tr><td>clergyman, clergywoman</td><td>clergyperson, clergy member</td></tr>
+    <tr><td>clergyman, clergywoman</td><td>clergyperson, clergy member, cleric, preacher</td></tr>
     <tr><td>councilman, councilwoman</td><td>councilperson, council member</td></tr>
     <tr><td>committeeman, committeewoman</td><td>committeeperson, committee member</td></tr>
     <tr><td>confidence-man, confidence-woman, con man, con woman</td><td>confidence-person, swindler, crook, trickster, con artist</td></tr>

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>boss man, boss woman</td><td>boss, chief, president, leader</td></tr>
     <tr><td>brakeman, brakewoman</td><td>brake operator, train conductor's assistant</td></tr>
     <tr><td>businessman, businesswoman</td><td>businessperson, executive, manager</td></tr>
-    <tr><td>cameraman, camerawoman</td><td>cameraperson, camera operator, cinematographer</td></tr>
+    <tr><td>cameraman, camerawoman, camera man, camera woman</td><td>cameraperson, camera person, camera operator, cinematographer</td></tr>
     <tr><td>careerman, careerwoman</td><td>careerperson, business person, professional, careerist</td></tr>
     <tr><td>caveman, cavewoman, cave man, cave woman</td><td>caveperson, cave person, cave dweller, prehistoric human, prehistoric person, primitive person</td></tr>
     <tr><td>chairman, chairwoman</td><td>chair, chairperson, coordinator, head, president, director</td></tr>

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>bondsman, bondswoman</td><td>bondsperson, guarantor, insurer</td></tr>
     <tr><td>boss man, boss woman</td><td>boss, chief, president, leader</td></tr>
     <tr><td>brakeman, brakewoman</td><td>brake operator, train conductor's assistant</td></tr>
-    <tr><td>businessman, businesswoman</td><td>businessperson, executive, manager</td></tr>
+    <tr><td>businessman, businesswoman, business man, business woman</td><td>businessperson, business person, executive, manager</td></tr>
     <tr><td>cameraman, camerawoman, camera man, camera woman</td><td>cameraperson, camera person, camera operator, cinematographer</td></tr>
     <tr><td>careerman, careerwoman</td><td>careerperson, business person, professional, careerist</td></tr>
     <tr><td>caveman, cavewoman, cave man, cave woman</td><td>caveperson, cave person, cave dweller, prehistoric human, prehistoric person, primitive person</td></tr>

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>sportsmanship, sportswomanship</td><td>sportspersonship, sportship, sporting, sporty</td></tr>
     <tr><td>statesman, stateswoman</td><td>statesperson, political leader, policy maker, diplomat</td></tr>
     <tr><td>strongman, strongwoman</td><td>bodybuilder, strength athlete</td></tr>
-    <tr><td>watchman, watchwoman</td><td>watchperson, guard, attendant, security officer</td></tr>
+    <tr><td>watchman, watchwoman</td><td>watchperson, guard, attendant, security officer, security guard</td></tr>
     <tr><td>weatherman, weatherwoman</td><td>weatherperson, weathercaster, weather forecaster, weather reporter</td></tr>
   </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>patrolman, patrolwoman</td><td>patrolperson, patrol officer, patroller</td></tr>
     <tr><td>policeman, policewoman</td><td>police officer</td></tr>
     <tr><td>postman, postwoman</td><td>mail carrier, letter carrier, postal worker</td></tr>
-    <tr><td>pressman, presswoman</td><td>press operator, journalist</td></tr>
+    <tr><td>pressman, presswoman</td><td>press operator, journalist, reporter</td></tr>
     <tr><td>prodigal son, prodigal daughter</td><td>prodigal child, returning child</td></tr>
     <tr><td>repairman, repairwoman</td><td>repairperson, maintenance person, technician, repairer</td></tr>
     <tr><td>schoolboy, schoolgirl</td><td>schoolchild, student</td></tr>

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>crewman, crewwoman</td><td>crewperson, crew member</td></tr>
     <tr><td>dairyman, dairywoman</td><td>dairyperson, dairy farmer, dairy worker</td></tr>
     <tr><td>deliveryman, deliverywoman</td><td>deliveryperson, deliverer, courier, clerk</td></tr>
-    <tr><td>doorman, doorwoman</td><td>doorperson, door attendant, security guard</td></tr>
+    <tr><td>doorman, doorwoman, doorsman, doorswoman</td><td>doorperson, door attendant, doorkeeper, gatekeeper, security guard, porter, concierge</td></tr>
     <tr><td>draftsman, draftswoman, draughtsman, draughtswoman</td><td>draftsperson, draughtsperson, drafter</td></tr>
     <tr><td>enlisted man, enlisted woman</td><td>enlisted person, enlistee, soldier, recruit, private</td></tr>
     <tr><td>everyman, everywoman</td><td>everyperson, the common person, the average person, commoner, worker</td></tr>

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Roles with gender words can change to use pan-gender words.
     <tr><td>king, queen</td><td>monarch, the crown, your majesty</td></tr>
     <tr><td>prince, princess</td><td>royal, highness, heir to the throne, eminence, liege</td></tr>
     <tr><td>lord in waiting, lady in waiting</td><td>courtier, royal attendant, valet</td></tr>
+    <tr><td>butler, maid</td><td>domestic worker</td></tr>
   </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Expressions that involve gendered first names
     <tr><td>boyfriend, girlfriend</td><td>friend, date, partner, companion, consort, significant other, S/O, SO</td></tr>
     <tr><td>Father Time</td><td>time</td></tr>
     <tr><td>man, woman</td><td>person, individual, adult</td></tr>
-    <tr><td>mankind, womankind</td><td>people, humans, humanity</td></tr>
+    <tr><td>mankind, womankind</td><td>people, humans, humanity, humankind</td></tr>
     <tr><td>Mother Nature</td><td>nature</td></tr>
     <tr><td>husband, wife</td><td>spouse, consort</td></tr>
     <tr><td>widow, widower</td><td>bereaved spouse, bereaved person, widowed person</td></tr>

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>sportsmanlike, sportswomanlike</td><td>sportspersonlike, sportlike, sporting, sporty</td></tr>
     <tr><td>sportsmanship, sportswomanship</td><td>sportspersonship, sportship, sporting, sporty</td></tr>
     <tr><td>statesman, stateswoman</td><td>statesperson, political leader, policy maker, diplomat</td></tr>
+    <tr><td>strongman, strongwoman</td><td>bodybuilder, strength athlete</td></tr>
     <tr><td>watchman, watchwoman</td><td>watchperson, guard, attendant, security officer</td></tr>
     <tr><td>weatherman, weatherwoman</td><td>weatherperson, weathercaster, weather forecaster, weather reporter</td></tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>brakeman, brakewoman</td><td>brake operator, train conductor's assistant</td></tr>
     <tr><td>businessman, businesswoman</td><td>businessperson, executive, manager</td></tr>
     <tr><td>cameraman, camerawoman</td><td>cameraperson, camera operator, cinematographer</td></tr>
-    <tr><td>careerman, careerwoman</td><td>careerperson, business person, professional</td></tr>
+    <tr><td>careerman, careerwoman</td><td>careerperson, business person, professional, careerist</td></tr>
     <tr><td>caveman, cavewoman, cave man, cave woman</td><td>caveperson, cave person, cave dweller, prehistoric human, prehistoric person, primitive person</td></tr>
     <tr><td>chairman, chairwoman</td><td>chair, chairperson, coordinator, head, president, director</td></tr>
     <tr><td>clergyman, clergywoman</td><td>clergyperson, clergy member, cleric, preacher</td></tr>

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>fireman, firewoman</td><td>firefighter</td></tr>
     <tr><td>fisherman, fisherwoman</td><td>fisherperson, fisher, angler</td></tr>
     <tr><td>foreman, forewoman</td><td>foreperson, manager, supervisor</td></tr>
-    <tr><td>freshman, freshwoman</td><td>first-year student, first-year member</td></tr>
+    <tr><td>freshman, freshwoman</td><td>first-year student, first-year member, newcomer, novice, beginner</td></tr>
     <tr><td>gentleman, gentlewoman</td><td>gentleperson</td></tr>
     <tr><td>handyman, handywoman</td><td>handyperson, repair person, repairperson, maintenance worker</td></tr>
     <tr><td>horseman, horsewoman</td><td>horseperson, horse rider, equestrian</td></tr>

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>alderman, alderwoman</td><td>alderperson, council member</td></tr>
     <tr><td>anchorman, anchorwoman</td><td>anchor, anchorperson, commentator, newscaster</td></tr>
     <tr><td>assemblyman, assemblywoman</td><td>assemblyperson, assembly member</td></tr>
-    <tr><td>barman, barwoman</td><td>barperson, barkeeper</td></tr>
+    <tr><td>barman, barwoman, barmaid</td><td>barperson, barkeeper, bar-keeper, barkeep, bar-keep, bartender, bar-tender</td></tr>
     <tr><td>bondsman, bondswoman</td><td>bondsperson, guarantor, insurer</td></tr>
     <tr><td>boss man, boss woman</td><td>boss, chief, president, leader</td></tr>
     <tr><td>brakeman, brakewoman, brakesman, brakeswoman</td><td>brake operator, train conductor's assistant</td></tr>

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>cameraman, camerawoman</td><td>cameraperson, camera operator, cinematographer</td></tr>
     <tr><td>careerman, careerwoman</td><td>careerperson, business person, professional</td></tr>
     <tr><td>caveman, cavewoman</td><td>cave person, cave dweller</td></tr>
-    <tr><td>chairman, chairwoman</td><td>chair, chairperson, coordinator, head</td></tr>
+    <tr><td>chairman, chairwoman</td><td>chair, chairperson, coordinator, head, president, director</td></tr>
     <tr><td>clergyman, clergywoman</td><td>clergyperson, clergy member, cleric, preacher</td></tr>
     <tr><td>councilman, councilwoman</td><td>councilperson, council member</td></tr>
     <tr><td>committeeman, committeewoman</td><td>committeeperson, committee member</td></tr>

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>contact-man, contact-woman</td><td>contact-person, contact, coordinator</td></tr>
     <tr><td>countryman, countrywoman</td><td>countryperson, compatriot, fellow citizen</td></tr>
     <tr><td>craftsman, craftswoman</td><td>craftsperson, crafter, craft maker, artisan</td></tr>
-    <tr><td>crewman, crewwoman</td><td>crewperson, crew member</td></tr>
+    <tr><td>crewman, crewwoman</td><td>crewperson, crewmate, crew member</td></tr>
     <tr><td>dairyman, dairywoman, dairymaid</td><td>dairyperson, dairy farmer, dairy worker</td></tr>
     <tr><td>deliveryman, deliverywoman, delivery man, delivery woman</td><td>deliveryperson, delivery person, delivery driver, deliverer, courier, clerk</td></tr>
     <tr><td>doorman, doorwoman, doorsman, doorswoman</td><td>doorperson, door attendant, doorkeeper, gatekeeper, security guard, porter, concierge</td></tr>

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>craftsman, craftswoman</td><td>craftsperson, crafter, craft maker, artisan</td></tr>
     <tr><td>crewman, crewwoman</td><td>crewperson, crew member</td></tr>
     <tr><td>dairyman, dairywoman</td><td>dairyperson, dairy farmer, dairy worker</td></tr>
-    <tr><td>deliveryman, deliverywoman</td><td>deliveryperson, deliverer, courier, clerk</td></tr>
+    <tr><td>deliveryman, deliverywoman, delivery man, delivery woman</td><td>deliveryperson, delivery person, delivery driver, deliverer, courier, clerk</td></tr>
     <tr><td>doorman, doorwoman, doorsman, doorswoman</td><td>doorperson, door attendant, doorkeeper, gatekeeper, security guard, porter, concierge</td></tr>
     <tr><td>draftsman, draftswoman, draughtsman, draughtswoman</td><td>draftsperson, draughtsperson, drafter</td></tr>
     <tr><td>enlisted man, enlisted woman</td><td>enlisted person, enlistee, soldier, recruit, private</td></tr>

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>enlisted man, enlisted woman</td><td>enlisted person, enlistee, soldier, recruit, private</td></tr>
     <tr><td>everyman, everywoman</td><td>everyperson, the common person, the average person, commoner, worker</td></tr>
     <tr><td>fall guy, fall gal</td><td>fall person, scapegoat</td></tr>
+    <tr><td>fellowman, fellowwoman</td><td>human person, person, fellow citizen, peer, partner, comrade</td></tr>
     <tr><td>fireman, firewoman</td><td>firefighter</td></tr>
     <tr><td>fisherman, fisherwoman</td><td>fisherperson, fisher, angler</td></tr>
     <tr><td>foreman, forewoman</td><td>foreperson, manager, supervisor, captain, team leader</td></tr>

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>businessman, businesswoman</td><td>businessperson, executive, manager</td></tr>
     <tr><td>cameraman, camerawoman</td><td>cameraperson, camera operator, cinematographer</td></tr>
     <tr><td>careerman, careerwoman</td><td>careerperson, business person, professional</td></tr>
-    <tr><td>caveman, cavewoman</td><td>cave person, cave dweller</td></tr>
+    <tr><td>caveman, cavewoman, cave man, cave woman</td><td>caveperson, cave person, cave dweller, prehistoric human, prehistoric person, primitive person</td></tr>
     <tr><td>chairman, chairwoman</td><td>chair, chairperson, coordinator, head, president, director</td></tr>
     <tr><td>clergyman, clergywoman</td><td>clergyperson, clergy member, cleric, preacher</td></tr>
     <tr><td>councilman, councilwoman</td><td>councilperson, council member</td></tr>

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Roles with gender words can change to use pan-gender words.
     <tr><td>prince, princess</td><td>royal, highness, heir to the throne, eminence, liege</td></tr>
     <tr><td>lord in waiting, lady in waiting</td><td>courtier, royal attendant, valet</td></tr>
     <tr><td>butler, maid</td><td>domestic worker</td></tr>
+    <tr><td>midwife</td><td>obstetrician</td></tr>
   </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>foreman, forewoman</td><td>foreperson, manager, supervisor</td></tr>
     <tr><td>freshman, freshwoman</td><td>first-year student, first-year member</td></tr>
     <tr><td>gentleman, gentlewoman</td><td>gentleperson</td></tr>
-    <tr><td>handyman, handywoman</td><td>handyperson, repair person, maintenance worker</td></tr>
+    <tr><td>handyman, handywoman</td><td>handyperson, repair person, repairperson, maintenance worker</td></tr>
     <tr><td>horseman, horsewoman</td><td>horseperson, horse rider, equestrian</td></tr>
     <tr><td>layman, laywoman</td><td>layperson, church member, nonordained person</td></tr>
     <tr><td>kinsman, kinswoman</td><td>kinsperson, relative</td></tr>

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Phrases with "man" can change to use "one" or "person".
     <tr><td>no man is an island</td><td>no one is an island</td></tr>
     <tr><td>the common man</td><td>the common person, the average person</td></tr>
     <tr><td>the man in the street</td><td>the person in the street, the average person</td></tr>
-    <tr><td>the right man for the job</td><td>the right one for the job</td></tr>
+    <tr><td>the right man for the job</td><td>the right one for the job, the right person for the job</td></tr>
     <tr><td>to a man</td><td>to a one, each one, everyone, unanimous, without exception</td></tr>
     <tr><td>to the last man</td><td>to the last one</td></tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ Expressions that involve gendered first names
     <tr><td>niece, nephew</td><td>nibling</td></tr>
     <tr><td>aunt, uncle</td><td>auncle</td></tr>
     <tr><td>fraternal twins</td><td>differentiable twins, non-identical twins</td></tr>
+    <tr><td>godfather, godmother</td><td>godparent</td></tr>
   </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>clergyman, clergywoman</td><td>clergyperson, clergy member</td></tr>
     <tr><td>councilman, councilwoman</td><td>councilperson, council member</td></tr>
     <tr><td>committeeman, committeewoman</td><td>committeeperson, committee member</td></tr>
-    <tr><td>confidence-man, confidence-woman</td><td>confidence-person, swindler, crook</td></tr>
+    <tr><td>confidence-man, confidence-woman, con man, con woman</td><td>confidence-person, swindler, crook, trickster, con artist</td></tr>
     <tr><td>congressman, congresswoman</td><td>congressperson, congressional representative, legislator, lawmaker, congressional delegate</td></tr>
     <tr><td>contact-man, contact-woman, contact man, contact woman</td><td>contact-person, contact person, contact, coordinator</td></tr>
     <tr><td>countryman, countrywoman</td><td>countryperson, compatriot, fellow citizen, fellow national</td></tr>

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>barman, barwoman</td><td>barperson, barkeeper</td></tr>
     <tr><td>bondsman, bondswoman</td><td>bondsperson, guarantor, insurer</td></tr>
     <tr><td>boss man, boss woman</td><td>boss, chief, president, leader</td></tr>
-    <tr><td>brakeman, brakewoman</td><td>brake operator, train conductor's assistant</td></tr>
+    <tr><td>brakeman, brakewoman, brakesman, brakeswoman</td><td>brake operator, train conductor's assistant</td></tr>
     <tr><td>businessman, businesswoman, business man, business woman</td><td>businessperson, business person, executive, manager</td></tr>
     <tr><td>cameraman, camerawoman, camera man, camera woman</td><td>cameraperson, camera person, camera operator, cinematographer</td></tr>
     <tr><td>careerman, careerwoman</td><td>careerperson, business person, professional, careerist</td></tr>

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Expressions that involve gendered first names
     <tr><td>man, woman</td><td>person, individual, adult</td></tr>
     <tr><td>mankind, womankind</td><td>people, humans, humanity</td></tr>
     <tr><td>husband, wife</td><td>spouse, consort</td></tr>
+    <tr><td>widow, widower</td><td>bereaved spouse, bereaved person, widowed person</td></tr>
   <tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -326,10 +326,8 @@ Expressions that involve gendered first names
   <tbody>
     <tr><td>boy, girl</td><td>person, individual, child</td></tr>
     <tr><td>boyfriend, girlfriend</td><td>friend, date, partner, companion, consort, significant other, S/O, SO</td></tr>
-    <tr><td>Father Time</td><td>time</td></tr>
     <tr><td>man, woman</td><td>person, individual, adult</td></tr>
     <tr><td>mankind, womankind</td><td>people, humans, humanity, humankind</td></tr>
-    <tr><td>Mother Nature</td><td>nature</td></tr>
     <tr><td>husband, wife</td><td>spouse, consort</td></tr>
     <tr><td>widow, widower</td><td>bereaved spouse, bereaved person, widowed person</td></tr>
   <tbody>
@@ -410,12 +408,14 @@ Expressions that involve gendered first names
     <tr><td>brotherly, sisterly</td><td>siblingly, kindly, helpfully</td></tr>
     <tr><td>brotherly love, sisterly love</td><td>siblingly love, charity, goodwill</td></tr>
     <tr><td>coed</td><td>student</td></tr>
+    <tr><td>Father Time</td><td>time</td></tr>
     <tr><td>man (verb)</td><td>to guard, to staff, to operate, to mind [the store]</td></tr>
     <tr><td>man-made, woman-made</td><td>human-made, synthetic, artificial, hand-made, machine-made</td></tr>
     <tr><td>manhole</td><td>utility hole, access hole, sewer hole, maintenance hole</td></tr>
     <tr><td>manpower, womanpower</td><td>personpower, teampower, workers, workforce, staff</td></tr>
     <tr><td>meter-maid, meter-matron, meter-man</td><td>meter-reader, parking enforcement officer, PEO, parking officer, parking inspector, traffic warden, civil enforcement officer</td></tr>
     <tr><td>motherland, fatherland</td><td>homeland</td></tr>
+    <tr><td>Mother Nature</td><td>nature</td></tr>
   </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -326,8 +326,10 @@ Expressions that involve gendered first names
   <tbody>
     <tr><td>boy, girl</td><td>person, individual, child</td></tr>
     <tr><td>boyfriend, girlfriend</td><td>friend, date, partner, companion, consort, significant other, S/O, SO</td></tr>
+    <tr><td>Father Time</td><td>time</td></tr>
     <tr><td>man, woman</td><td>person, individual, adult</td></tr>
     <tr><td>mankind, womankind</td><td>people, humans, humanity</td></tr>
+    <tr><td>Mother Nature</td><td>nature</td></tr>
     <tr><td>husband, wife</td><td>spouse, consort</td></tr>
     <tr><td>widow, widower</td><td>bereaved spouse, bereaved person, widowed person</td></tr>
   <tbody>

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>fall guy, fall gal</td><td>fall person, scapegoat</td></tr>
     <tr><td>fireman, firewoman</td><td>firefighter</td></tr>
     <tr><td>fisherman, fisherwoman</td><td>fisherperson, fisher, angler</td></tr>
-    <tr><td>foreman, forewoman</td><td>foreperson, manager, supervisor</td></tr>
+    <tr><td>foreman, forewoman</td><td>foreperson, manager, supervisor, captain, team leader</td></tr>
     <tr><td>freshman, freshwoman</td><td>first-year student, first-year member, newcomer, novice, beginner</td></tr>
     <tr><td>gentleman, gentlewoman</td><td>gentleperson</td></tr>
     <tr><td>handyman, handywoman</td><td>handyperson, repair person, repairperson, maintenance worker</td></tr>

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>dairyman, dairywoman</td><td>dairyperson, dairy farmer, dairy worker</td></tr>
     <tr><td>deliveryman, deliverywoman</td><td>deliveryperson, deliverer, courier, clerk</td></tr>
     <tr><td>doorman, doorwoman</td><td>doorperson, door attendant, security guard</td></tr>
-    <tr><td>draftsman, draftswoman</td><td>draftsperson, drafter</td></tr>
+    <tr><td>draftsman, draftswoman, draughtsman, draughtswoman</td><td>draftsperson, draughtsperson, drafter</td></tr>
     <tr><td>enlisted man, enlisted woman</td><td>enlisted person, enlistee, soldier, recruit, private</td></tr>
     <tr><td>everyman, everywoman</td><td>everyperson, the common person, the average person, commoner, worker</td></tr>
     <tr><td>fall guy, fall gal</td><td>fall person, scapegoat</td></tr>

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>committeeman, committeewoman</td><td>committeeperson, committee member</td></tr>
     <tr><td>confidence-man, confidence-woman</td><td>confidence-person, swindler, crook</td></tr>
     <tr><td>congressman, congresswoman</td><td>congressperson, congressional representative, legislator</td></tr>
-    <tr><td>contact-man, contact-woman</td><td>contact-person, contact, coordinator</td></tr>
-    <tr><td>countryman, countrywoman</td><td>countryperson, compatriot, fellow citizen</td></tr>
+    <tr><td>contact-man, contact-woman, contact man, contact woman</td><td>contact-person, contact person, contact, coordinator</td></tr>
+    <tr><td>countryman, countrywoman</td><td>countryperson, compatriot, fellow citizen, fellow national</td></tr>
     <tr><td>craftsman, craftswoman</td><td>craftsperson, crafter, craft maker, artisan</td></tr>
     <tr><td>crewman, crewwoman</td><td>crewperson, crewmate, crew member</td></tr>
     <tr><td>dairyman, dairywoman, dairymaid</td><td>dairyperson, dairy farmer, dairy worker</td></tr>

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>countryman, countrywoman</td><td>countryperson, compatriot, fellow citizen</td></tr>
     <tr><td>craftsman, craftswoman</td><td>craftsperson, crafter, craft maker, artisan</td></tr>
     <tr><td>crewman, crewwoman</td><td>crewperson, crew member</td></tr>
-    <tr><td>dairyman, dairywoman</td><td>dairyperson, dairy farmer, dairy worker</td></tr>
+    <tr><td>dairyman, dairywoman, dairymaid</td><td>dairyperson, dairy farmer, dairy worker</td></tr>
     <tr><td>deliveryman, deliverywoman, delivery man, delivery woman</td><td>deliveryperson, delivery person, delivery driver, deliverer, courier, clerk</td></tr>
     <tr><td>doorman, doorwoman, doorsman, doorswoman</td><td>doorperson, door attendant, doorkeeper, gatekeeper, security guard, porter, concierge</td></tr>
     <tr><td>draftsman, draftswoman, draughtsman, draughtswoman</td><td>draftsperson, draughtsperson, drafter</td></tr>

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Roles that end with gendered suffix "-boy" or "-girl" can change to "-person" or
     <tr><td>bagboy, baggirl, bag boy, bag girl</td><td>bagperson, bagger, assistant, caddy</td></tr>
     <tr><td>batboy, batgirl, bat boy, bat girl</td><td>batperson, bat assistant, caddy</td></tr>
     <tr><td>bellboy, bellgirl, bell-boy, bell-girl</td><td>bellperson, bellhop, hotel attendant</td></tr>
+    <tr><td>boy wonder, girl wonder</td><td>child prodigy</td></tr>
     <tr><td>busboy, busgirl</td><td>busperson, busser, bus staffer, kitchen helper</td></tr>
     <tr><td>cabinboy, cabingirl</td><td>cabinperson, cabin attendant, cabin helper</td></tr>
     <tr><td>choirboy, choirgirl</td><td>choirperson, choir member, choir singer</td></tr>

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>ombudsman, ombudswoman</td><td>ombudsperson, investigator, appointee</td></tr>
     <tr><td>outdoorsman, outdoorswoman</td><td>outdoors person</td></tr>
     <tr><td>patrolman, patrolwoman</td><td>patrolperson, patrol officer, patroller</td></tr>
-    <tr><td>policeman, policewoman</td><td>police officer</td></tr>
+    <tr><td>policeman, policewoman</td><td>police officer, law enforcement officer</td></tr>
     <tr><td>postman, postwoman</td><td>mail carrier, letter carrier, postal worker</td></tr>
     <tr><td>pressman, presswoman</td><td>press operator, journalist, reporter</td></tr>
     <tr><td>prodigal son, prodigal daughter</td><td>prodigal child, returning child</td></tr>

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>deliveryman, deliverywoman</td><td>deliveryperson, deliverer, courier, clerk</td></tr>
     <tr><td>doorman, doorwoman</td><td>doorperson, door attendant, security guard</td></tr>
     <tr><td>draftsman, draftswoman</td><td>draftsperson, drafter</td></tr>
-    <tr><td>enlisted man, enlisted woman</td><td>enlisted person, enlistee, soldier, recruit</td></tr>
+    <tr><td>enlisted man, enlisted woman</td><td>enlisted person, enlistee, soldier, recruit, private</td></tr>
     <tr><td>everyman, everywoman</td><td>everyperson, the common person, the average person, commoner, worker</td></tr>
     <tr><td>fall guy, fall gal</td><td>fall person, scapegoat</td></tr>
     <tr><td>fireman, firewoman</td><td>firefighter</td></tr>

--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ Expressions that involve gendered first names
   </thead>
   <tbody>
     <tr><td>mother, father</td><td>parent</td></tr>
+    <tr><td>mother figure, father figure</td><td>parental figure</td></tr>
     <tr><td>motherhood, fatherhood</td><td>parenthood</td></tr>
     <tr><td>daughter, son</td><td>child</td></tr>
     <tr><td>sister, brother</td><td>sibling</td></tr>

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>councilman, councilwoman</td><td>councilperson, council member</td></tr>
     <tr><td>committeeman, committeewoman</td><td>committeeperson, committee member</td></tr>
     <tr><td>confidence-man, confidence-woman</td><td>confidence-person, swindler, crook</td></tr>
-    <tr><td>congressman, congresswoman</td><td>congressperson, congressional representative, legislator</td></tr>
+    <tr><td>congressman, congresswoman</td><td>congressperson, congressional representative, legislator, lawmaker, congressional delegate</td></tr>
     <tr><td>contact-man, contact-woman, contact man, contact woman</td><td>contact-person, contact person, contact, coordinator</td></tr>
     <tr><td>countryman, countrywoman</td><td>countryperson, compatriot, fellow citizen, fellow national</td></tr>
     <tr><td>craftsman, craftswoman</td><td>craftsperson, crafter, craft maker, artisan</td></tr>

--- a/README.md
+++ b/README.md
@@ -272,7 +272,6 @@ Phrases with "man" can change to use "one" or "person".
     <tr><td>founding fathers, founding mothers</td><td>founding parents, founding leaders, founders</td></tr>
     <tr><td>gentlemen's agreement, gentlewomen's agreement</td><td>unwritten agreement, honor agreement</td></tr>
     <tr><td>grandfather clause, grandmother clause</td><td>pre-existing clause, pre-defined clause</td></tr>
-    <tr><td>John Q. Public, Jane Q. Public</td><td>the public</td></tr>
     <tr><td>low man on the totem pole</td><td>low person on the list, least one in the group</td></tr>
     <tr><td>maiden voyage</td><td>first voyage</td></tr>
     <tr><td>man about town, woman about town</td><td>bon vivant, mover and shaker</td></tr>
@@ -289,6 +288,28 @@ Phrases with "man" can change to use "one" or "person".
     <tr><td>the right man for the job</td><td>the right one for the job</td></tr>
     <tr><td>to a man</td><td>to a one, each one, everyone, unanimous, without exception</td></tr>
     <tr><td>to the last man</td><td>to the last one</td></tr>
+  </tbody>
+</table>
+
+## Idiomatic uses of Names and Placeholder Names
+
+Expressions that involve gendered first names
+
+<table class="words">
+  <thead>
+    <tr><td><b>Gender-exclusive</b></td><td><b>Gender-inclusive</b></td></tr>
+  </thead>
+  <tbody>
+    <tr><td>Average Joe</td><td>average person</td></tr>
+    <tr><td>Jo Schmoe, Joe Schmo, Joe Shmo, Joe Shmoe</td><td>the public</td></tr>
+    <tr><td>Jack of all trades, Jill of all trades</td><td>all-rounder</td></tr>
+    <tr><td>John Doe, Jane Doe</td><td>unnamed individual, unidentified individual</td></tr>
+    <tr><td>John Q. Public, Jane Q. Public</td><td>the public</td></tr>
+    <tr><td>Jolly Roger</td><td>pirate flag</td></tr>
+    <tr><td>Lazy Susan</td><td>turntable</td></tr>
+    <tr><td>Peeping Tom</td><td>voyeur</td></tr>
+    <tr><td>Smart Alec</td><td>turntable</td></tr>
+    <tr><td>Tom Dick and Harry</td><td>anyone, everyone</td></tr>
   </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td><b>Gender-exclusive</b></td><td><b>Gender-inclusive</b></td></tr>
   </thead>
   <tbody>
-    <tr><td>ad-man, ad-woman</td><td>ad-person, advertising executive, promoter</td></tr>
+    <tr><td>ad-man, ad-woman, adman, adwoman</td><td>ad-person, adperson, advertising executive, ad executive, advertising agent, ad agent, promoter</td></tr>
     <tr><td>airman, airwoman</td><td>airperson, air crew member, pilot</td></tr>
     <tr><td>alderman, alderwoman</td><td>alderperson, council member</td></tr>
     <tr><td>anchorman, anchorwoman</td><td>anchor, anchorperson, commentator, newscaster</td></tr>

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Roles that end with gendered suffix "-man" or "-woman" can change to end with "p
     <tr><td>doorman, doorwoman</td><td>doorperson, door attendant, security guard</td></tr>
     <tr><td>draftsman, draftswoman</td><td>draftsperson, drafter</td></tr>
     <tr><td>enlisted man, enlisted woman</td><td>enlisted person, enlistee, soldier, recruit</td></tr>
-    <tr><td>everyman, everywoman</td><td>everyperson, the common person, the average person</td></tr>
+    <tr><td>everyman, everywoman</td><td>everyperson, the common person, the average person, commoner, worker</td></tr>
     <tr><td>fall guy, fall gal</td><td>fall person, scapegoat</td></tr>
     <tr><td>fireman, firewoman</td><td>firefighter</td></tr>
     <tr><td>fisherman, fisherwoman</td><td>fisherperson, fisher, angler</td></tr>


### PR DESCRIPTION
Genuinely not sure if this is what you meant. If not, it's fine, you can manually fix. I made all the notes I could need for my research elsewhere so I don't depend on the tracking here.

The only necessary notes for me, btw, were which changes were suggested by GPT (and OK'd by me), about 6 in total. Because a resource such as this is not easily solved with pre-existing tools, collective human intelligence and a Large Language Model really are the only real way to approach an exhaustive list of gendered English nouns and their gender-neutral counterpart.
I tried using WordNet before I found this and `fireman` and `firefigher` was literally the only such pair it contains.

What I did find using WordNet is a bunch of near-matches like `actor` and `actress`, meaning that the supposed neutral word is actually ambiguous because it used to be the male one, but the female counterpart is on its way out now, thus letting the male word become neutral. WordNet has dozens of those (adulterer/adulteress, murderer/murderess, emperor/empress, major/majorette, all kinds of -tor&-trix pairs …). I could compile them and send them your way if you're interested.

I'll move on with my research for now, but I might be back occasionally to try adding to this.

Thanks for your patience.